### PR TITLE
build: add link against Threads library, as it is used by the ExecutorService

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -21,6 +21,8 @@ SET(KEYPLE_PLUGIN_DIR      "../../../keyple-plugin-cpp-api")
 SET(KEYPLE_UTIL_DIR        "../../../keyple-util-cpp-lib")
 SET(KEYPLE_UTIL_LIB        "keypleutilcpplib")
 
+FIND_PACKAGE(Threads REQUIRED)
+
 INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
@@ -93,4 +95,4 @@ ADD_LIBRARY(
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/Job.cpp
 )
 
-TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${KEYPLE_UTIL_LIB})
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${KEYPLE_UTIL_LIB} Threads::Threads)


### PR DESCRIPTION
This is a C++ building best practice to link against what is used, as it can cause link errors downstream